### PR TITLE
Now saving pshtt, tmail, and sslyze results in the same database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,18 +3,10 @@ version: '3.2'
 secrets:
   cyhy_read_creds:
     file: ./secrets/cyhy_read_creds.yml
-  pshtt_read_creds:
-    file: ./secrets/pshtt_read_creds.yml
-  pshtt_write_creds:
-    file: ./secrets/pshtt_write_creds.yml
-  trustymail_read_creds:
-    file: ./secrets/trustymail_read_creds.yml
-  trustymail_write_creds:
-    file: ./secrets/trustymail_write_creds.yml
-  sslyze_read_creds:
-    file: ./secrets/sslyze_read_creds.yml
-  sslyze_write_creds:
-    file: ./secrets/sslyze_write_creds.yml
+  scan_read_creds:
+    file: ./secrets/scan_read_creds.yml
+  scan_write_creds:
+    file: ./secrets/scan_write_creds.yml
   aws_config:
     file: ./secrets/aws/config
   aws_creds:
@@ -59,12 +51,8 @@ services:
     depends_on:
       - redis
     secrets:
-      - source: pshtt_write_creds
-        target: pshtt_write_creds.yml
-      - source: trustymail_write_creds
-        target: trustymail_write_creds.yml
-      - source: sslyze_write_creds
-        target: sslyze_write_creds.yml
+      - source: scan_write_creds
+        target: scan_write_creds.yml
     volumes:
       - /tmp:/home/saver/shared
   trustymail_report:
@@ -72,10 +60,8 @@ services:
     depends_on:
       - redis
     secrets:
-      - source: trustymail_read_creds
-        target: trustymail_read_creds.yml
-      - source: sslyze_read_creds
-        target: sslyze_read_creds.yml
+      - source: scan_read_creds
+        target: scan_read_creds.yml
     volumes:
       - /tmp:/home/reporter/shared
   pshtt_report:
@@ -83,9 +69,7 @@ services:
     depends_on:
       - redis
     secrets:
-      - source: pshtt_read_creds
-        target: pshtt_read_creds.yml
-      - source: sslyze_read_creds
-        target: sslyze_read_creds.yml
+      - source: scan_read_creds
+        target: scan_read_creds.yml
     volumes:
       - /tmp:/home/reporter/shared


### PR DESCRIPTION
Now saving pshtt, tmail, and sslyze results in the same database, which reduces the number of credentials files we need.