### PR TITLE
Adding support for AWS CodePipeline

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,10 +3,8 @@ version: 0.2
 phases:
   install:
     commands:
-      - echo Updating and installing docker-compose
       - apt-get update -y
-      - apt-get install docker-compose -y
+      - pip install docker-compose
   pre_build:
     commands:
-      - echo Verifying docker-compose.yml syntax
       - docker-compose config --quiet

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,12 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - echo Updating and installing docker-compose
+      - apt-get update -y
+      - apt-get install docker-compose -y
+  pre_build:
+    commands:
+      - echo Verifying docker-compose.yml syntax
+      - docker-compose config --quiet

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     commands:
-      - apt-get update -y
+      # - apt-get update -y
       - pip install docker-compose
   pre_build:
     commands:

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/terraform/codebuild.tf
+++ b/terraform/codebuild.tf
@@ -1,0 +1,97 @@
+# IAM assume role policy document for the role we're creating
+data "aws_iam_policy_document" "build_assume_role_doc" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["codebuild.amazonaws.com"]
+    }
+  }
+}
+
+# The role we're creating
+resource "aws_iam_role" "build_role" {
+  assume_role_policy = "${data.aws_iam_policy_document.build_assume_role_doc.json}"
+}
+
+# IAM policy document that that allows some S3 permissions on our
+# pipeline bucket.  This will be applied to the role we are creating.
+data "aws_iam_policy_document" "build_s3_doc" {
+  statement {
+    effect = "Allow"
+    
+    actions = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.pipeline_bucket.arn}/*"
+    ]
+  }
+}
+
+# The S3 policy for our role
+resource "aws_iam_role_policy" "build_s3_policy" {
+  role = "${aws_iam_role.build_role.id}"
+  policy = "${data.aws_iam_policy_document.build_s3_doc.json}"
+}
+
+# The Cloudwatch log group for the CodeBuild project
+resource "aws_cloudwatch_log_group" "logs" {
+  name = "/aws/codebuild/${aws_codebuild_project.project.name}"
+  retention_in_days = 30
+
+  tags = "${var.tags}"
+}
+
+# IAM policy document that that allows some CloudWatch permissions.
+# This will be applied to the role we are creating.
+data "aws_iam_policy_document" "build_cloudwatch_doc" {
+  statement {
+    effect = "Allow"
+    
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.logs.arn}"
+    ]
+  }
+}
+
+# The CloudWatch policy for our role
+resource "aws_iam_role_policy" "build_cloudwatch_policy" {
+  role = "${aws_iam_role.build_role.id}"
+  policy = "${data.aws_iam_policy_document.build_cloudwatch_doc.json}"
+}
+
+# The CodeBuild project
+resource "aws_codebuild_project" "project" {
+  name = "orchestrator"
+  description  = "AWS CodeBuild for the DHS-NCATS orchestrator project"
+  build_timeout = "60"
+  service_role = "${aws_iam_role.build_role.arn}"
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image = "aws/codebuild/docker:17.09.0"
+    type = "LINUX_CONTAINER"
+    privileged_mode = "true"
+  }
+
+  source {
+    type = "CODEPIPELINE"
+  }
+
+  tags = "${var.tags}"
+}

--- a/terraform/codebuild.tf
+++ b/terraform/codebuild.tf
@@ -176,7 +176,7 @@ resource "aws_codebuild_project" "project" {
     vpc_id = "${aws_vpc.build_vpc.id}"
     
     security_group_ids = [
-      "${aws_vpc.build_vpc.default_security_group_id}"
+      "${aws_security_group.build_private_sg.id}"
     ]
     
     subnets = [

--- a/terraform/codepipeline.tf
+++ b/terraform/codepipeline.tf
@@ -163,7 +163,7 @@ resource "aws_codepipeline" "pipeline" {
         Owner = "dhs-ncats"
         Repo = "orchestrator"
         Branch = "feature/codepipeline"
-        PollForSourceChanges = true
+        PollForSourceChanges = "true"
       }
     }
   }

--- a/terraform/codepipeline.tf
+++ b/terraform/codepipeline.tf
@@ -1,0 +1,188 @@
+# The S3 bucket where build artifacts are stored
+resource "aws_s3_bucket" "pipeline_bucket" {
+  bucket = "orchestrator-codepipeline"
+  acl = "private"
+
+  tags = "${var.tags}"
+}
+
+# IAM policy document that disallows unencrypted object uploads and
+# insecure connections.
+data "aws_iam_policy_document" "pipeline_bucket_doc" {
+  # Deny unencrypted uploads
+  statement {
+    effect = "Deny"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "*"
+      ]
+    }
+    
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.pipeline_bucket.arn}/*"
+    ]
+
+    condition {
+      test = "StringNotEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values = [
+        "aws:kms"
+      ]
+    }
+  }
+
+  # Deny unsecure connections
+  statement {
+    effect = "Deny"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "*"
+      ]
+    }
+    
+    actions = [
+      "s3:*"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.pipeline_bucket.arn}/*"
+    ]
+
+    condition {
+      test = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+}
+
+# This is the policy for our pipeline bucket
+resource "aws_s3_bucket_policy" "pipeline_bucket_policy" {
+  bucket = "${aws_s3_bucket.pipeline_bucket.id}"
+  policy = "${data.aws_iam_policy_document.pipeline_bucket_doc.json}"
+}
+
+# IAM assume role policy document for the role we're creating
+data "aws_iam_policy_document" "pipeline_assume_role_doc" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["codepipeline.amazonaws.com"]
+    }
+  }
+}
+
+# The role we're creating
+resource "aws_iam_role" "pipeline_role" {
+  assume_role_policy = "${data.aws_iam_policy_document.pipeline_assume_role_doc.json}"
+}
+
+# IAM policy document that that allows some S3 permissions on our
+# pipeline bucket.  This will be applied to the role we are creating.
+data "aws_iam_policy_document" "pipeline_s3_doc" {
+  statement {
+    effect = "Allow"
+    
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.pipeline_bucket.arn}/*"
+    ]
+  }
+}
+
+# The S3 policy for our role
+resource "aws_iam_role_policy" "pipeline_s3_policy" {
+  role = "${aws_iam_role.pipeline_role.id}"
+  policy = "${data.aws_iam_policy_document.pipeline_s3_doc.json}"
+}
+
+# IAM policy document that that allows some CodeBuild permissions.
+# This will be applied to the role we are creating.
+data "aws_iam_policy_document" "pipeline_codebuild_doc" {
+  statement {
+    effect = "Allow"
+    
+    actions = [
+      "codebuild:StartBuild",
+      "codebuild:BatchGetBuilds"
+    ]
+
+    resources = [
+      "${aws_codebuild_project.project.id}"
+    ]
+  }
+}
+
+# The CodeBuild policy for our role
+resource "aws_iam_role_policy" "pipeline_codebuild_policy" {
+  role = "${aws_iam_role.pipeline_role.id}"
+  policy = "${data.aws_iam_policy_document.pipeline_codebuild_doc.json}"
+}
+
+# The CodePipeline for CI/CD
+resource "aws_codepipeline" "pipeline" {
+  name = "orchestrator"
+  role_arn = "${aws_iam_role.pipeline_role.arn}"
+
+  artifact_store {
+    location = "${aws_s3_bucket.pipeline_bucket.bucket}"
+    type = "S3"
+  }
+
+  # Grab the source code
+  stage {
+    name = "Source"
+    action {
+      name = "Source"
+      category = "Source"
+      owner = "ThirdParty"
+      provider = "GitHub"
+      version = "1"
+      output_artifacts = [
+        "source"
+      ]
+
+      configuration {
+        Owner = "dhs-ncats"
+        Repo = "orchestrator"
+        Branch = "feature/codepipeline"
+        PollForSourceChanges = true
+      }
+    }
+  }
+
+  # Run the CodeBuild project
+  stage {
+    name = "Build"
+    action {
+      name = "CodeBuild"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      version = "1"
+      input_artifacts = ["source"]
+      output_artifacts = ["build"]
+
+      configuration {
+        ProjectName = "orchestrator"
+      }
+    }
+  }
+}

--- a/terraform/codepipeline.tf
+++ b/terraform/codepipeline.tf
@@ -4,6 +4,15 @@ resource "aws_s3_bucket" "pipeline_bucket" {
   acl = "private"
   force_destroy = "true"
 
+  # Destroy objects after 30 days
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+
   tags = "${var.tags}"
 }
 

--- a/terraform/codepipeline.tf
+++ b/terraform/codepipeline.tf
@@ -2,6 +2,7 @@
 resource "aws_s3_bucket" "pipeline_bucket" {
   bucket = "orchestrator-codepipeline"
   acl = "private"
+  force_destroy = "true"
 
   tags = "${var.tags}"
 }

--- a/terraform/codepipeline.tf
+++ b/terraform/codepipeline.tf
@@ -4,6 +4,14 @@ resource "aws_s3_bucket" "pipeline_bucket" {
   acl = "private"
   force_destroy = "true"
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   # Destroy objects after 30 days
   lifecycle_rule {
     enabled = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,7 @@
+# Configure the AWS provider
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+# The AWS account ID being used
+data "aws_caller_identity" "current" {}

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -1,0 +1,6 @@
+aws_region = "us-east-1"
+
+tags = {
+  Team = "NCATS OIS - Development"
+  Application = "orchestrator CI/CD"
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    encrypt = true
+    bucket = "ncats-terraform-remote-state-storage"
+    dynamodb_table = "terraform-state-lock"
+    region = "us-east-1"
+    key = "orchestrator-codepipeline/terraform.tfstate"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "aws_region" {
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  default = "us-east-1"
+}
+
+variable "tags" {
+  type = "map"
+  default = {}
+  description = "Tags to apply to all AWS resources created"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -90,3 +90,177 @@ resource "aws_route_table_association" "association" {
   subnet_id = "${aws_subnet.build_public_subnet.id}"
   route_table_id = "${aws_route_table.build_public_route_table.id}"
 }
+
+# ACL for the private subnet of the VPC
+resource "aws_network_acl" "build_default_acl" {
+  vpc_id = "${aws_vpc.build_vpc.id}"
+  subnet_ids = [
+    "${aws_subnet.build_private_subnet.id}"
+  ]
+
+  # Allow ephemeral ports from anywhere
+  ingress {
+    protocol = "tcp"
+    rule_no = 100
+    action = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port = 1024
+    to_port = 65535
+  }
+
+  # Allow HTTP (needed for apt-get)
+  egress {
+    protocol = "tcp"
+    rule_no = 100
+    action = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port = 80
+    to_port = 80
+  }
+
+  # Allow HTTPS
+  egress {
+    protocol = "tcp"
+    rule_no = 110
+    action = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port = 443
+    to_port = 443
+  }
+
+  tags = "${var.tags}"
+}
+
+# ACL for the public-facing subnet of the VPC
+resource "aws_network_acl" "build_public_acl" {
+  vpc_id = "${aws_vpc.build_vpc.id}"
+  subnet_ids = [
+    "${aws_subnet.build_public_subnet.id}"
+  ]
+
+  # Allow ephemeral ports from anywhere
+  ingress {
+    protocol = "tcp"
+    rule_no = 100
+    action = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port = 0
+    to_port = 65535
+  }
+
+  # Allow HTTP (needed for apt-get)
+  egress {
+    protocol = "tcp"
+    rule_no = 100
+    action = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port = 80
+    to_port = 80
+  }
+
+  # Allow HTTPS
+  egress {
+    protocol = "tcp"
+    rule_no = 110
+    action = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port = 443
+    to_port = 443
+  }
+
+  # Allow egress to the private subnet via ephemeral ports
+  egress {
+    protocol = "tcp"
+    rule_no = 120
+    action = "allow"
+    cidr_block = "${aws_subnet.build_private_subnet.cidr_block}"
+    from_port = 1024
+    to_port = 65535
+  }
+
+  tags = "${var.tags}"
+}
+
+# Security group for the private portion of the VPC
+resource "aws_security_group" "build_private_sg" {
+  vpc_id = "${aws_vpc.build_vpc.id}"
+
+  # Allow ephemeral ports from anywhere
+  ingress {
+    protocol = "tcp"
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    from_port = 1024
+    to_port = 65535
+  }
+
+  # Allow HTTP (needed for apt-get)
+  egress {
+    protocol = "tcp"
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    from_port = 80
+    to_port = 80
+  }
+
+  # Allow HTTPS
+  egress {
+    protocol = "tcp"
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    from_port = 443
+    to_port = 443
+  }
+
+  tags = "${var.tags}"
+}
+
+# Security group for the public portion of the VPC
+resource "aws_security_group" "build_public_sg" {
+  vpc_id = "${aws_vpc.build_vpc.id}"
+
+  # Allow ephemeral ports from anywhere
+  ingress {
+    protocol = "tcp"
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    from_port = 1024
+    to_port = 65535
+  }
+
+  # Allow HTTP (needed for apt-get)
+  egress {
+    protocol = "tcp"
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    from_port = 80
+    to_port = 80
+  }
+
+  # Allow HTTPS
+  egress {
+    protocol = "tcp"
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    from_port = 443
+    to_port = 443
+  }
+
+  # Allow egress to the private subnet via ephemeral ports
+  egress {
+    protocol = "tcp"
+    cidr_blocks = [
+      "${aws_subnet.build_private_subnet.cidr_block}"
+    ]
+    from_port = 1024
+    to_port = 65535
+  }
+
+  tags = "${var.tags}"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,92 @@
+# The VPC within which we run our builds
+resource "aws_vpc" "build_vpc" {
+  cidr_block = "10.66.66.0/23"
+
+  tags = "${var.tags}"
+}
+
+# Public subnet of the VPC
+resource "aws_subnet" "build_public_subnet" {
+  vpc_id = "${aws_vpc.build_vpc.id}"
+  cidr_block = "10.66.67.0/24"
+
+  depends_on = [
+    "aws_internet_gateway.build_igw"
+  ]
+
+  tags = "${var.tags}"
+}
+
+# Subnet of the VPC in which we run our pipeline
+resource "aws_subnet" "build_private_subnet" {
+  vpc_id = "${aws_vpc.build_vpc.id}"
+  cidr_block = "10.66.66.0/24"
+
+  depends_on = [
+    "aws_internet_gateway.build_igw"
+  ]
+
+  tags = "${var.tags}"
+}
+
+# EIP for the NAT gateway
+resource "aws_eip" "build_eip" {
+  vpc = true
+  
+  depends_on = [
+    "aws_internet_gateway.build_igw"
+  ]
+
+  tags = "${var.tags}"
+}
+
+# The NAT gateway for the VPC
+resource "aws_nat_gateway" "build_nat_gw" {
+  allocation_id = "${aws_eip.build_eip.id}"
+  subnet_id = "${aws_subnet.build_public_subnet.id}"
+
+  depends_on = [
+    "aws_internet_gateway.build_igw"
+  ]
+
+  tags = "${var.tags}"
+}
+
+# The internet gateway for the VPC
+resource "aws_internet_gateway" "build_igw" {
+  vpc_id = "${aws_vpc.build_vpc.id}"
+
+  tags = "${var.tags}"
+}
+
+# Default route table, which routes all external traffic through the
+# NAT gateway
+resource "aws_default_route_table" "build_default_route_table" {
+  default_route_table_id = "${aws_vpc.build_vpc.default_route_table_id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    nat_gateway_id = "${aws_nat_gateway.build_nat_gw.id}"
+  }
+
+  tags = "${var.tags}"
+}
+
+# Route table for our public subnet, which routes all external traffic
+# through the internet gateway
+resource "aws_route_table" "build_public_route_table" {
+  vpc_id = "${aws_vpc.build_vpc.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.build_igw.id}"
+  }
+
+  tags = "${var.tags}"
+}
+
+# Associate the route table with the public subnet
+resource "aws_route_table_association" "association" {
+  subnet_id = "${aws_subnet.build_public_subnet.id}"
+  route_table_id = "${aws_route_table.build_public_route_table.id}"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -17,7 +17,7 @@ resource "aws_subnet" "build_public_subnet" {
   tags = "${var.tags}"
 }
 
-# Subnet of the VPC in which we run our pipeline
+# Private subnet of the VPC in which we run our pipeline
 resource "aws_subnet" "build_private_subnet" {
   vpc_id = "${aws_vpc.build_vpc.id}"
   cidr_block = "10.66.66.0/24"
@@ -92,7 +92,7 @@ resource "aws_route_table_association" "association" {
 }
 
 # ACL for the private subnet of the VPC
-resource "aws_network_acl" "build_default_acl" {
+resource "aws_network_acl" "build_private_acl" {
   vpc_id = "${aws_vpc.build_vpc.id}"
   subnet_ids = [
     "${aws_subnet.build_private_subnet.id}"
@@ -107,21 +107,21 @@ resource "aws_network_acl" "build_default_acl" {
     from_port = 1024
     to_port = 65535
   }
-
+  
   # Allow HTTP (needed for apt-get)
-  egress {
-    protocol = "tcp"
-    rule_no = 100
-    action = "allow"
-    cidr_block = "0.0.0.0/0"
-    from_port = 80
-    to_port = 80
-  }
+  # egress {
+  #   protocol = "tcp"
+  #   rule_no = 110
+  #   action = "allow"
+  #   cidr_block = "0.0.0.0/0"
+  #   from_port = 80
+  #   to_port = 80
+  # }
 
   # Allow HTTPS
   egress {
     protocol = "tcp"
-    rule_no = 110
+    rule_no = 120
     action = "allow"
     cidr_block = "0.0.0.0/0"
     from_port = 443
@@ -149,14 +149,14 @@ resource "aws_network_acl" "build_public_acl" {
   }
 
   # Allow HTTP (needed for apt-get)
-  egress {
-    protocol = "tcp"
-    rule_no = 100
-    action = "allow"
-    cidr_block = "0.0.0.0/0"
-    from_port = 80
-    to_port = 80
-  }
+  # egress {
+  #   protocol = "tcp"
+  #   rule_no = 100
+  #   action = "allow"
+  #   cidr_block = "0.0.0.0/0"
+  #   from_port = 80
+  #   to_port = 80
+  # }
 
   # Allow HTTPS
   egress {
@@ -196,14 +196,14 @@ resource "aws_security_group" "build_private_sg" {
   }
 
   # Allow HTTP (needed for apt-get)
-  egress {
-    protocol = "tcp"
-    cidr_blocks = [
-      "0.0.0.0/0"
-    ]
-    from_port = 80
-    to_port = 80
-  }
+  # egress {
+  #   protocol = "tcp"
+  #   cidr_blocks = [
+  #     "0.0.0.0/0"
+  #   ]
+  #   from_port = 80
+  #   to_port = 80
+  # }
 
   # Allow HTTPS
   egress {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -144,7 +144,7 @@ resource "aws_network_acl" "build_public_acl" {
     rule_no = 100
     action = "allow"
     cidr_block = "0.0.0.0/0"
-    from_port = 0
+    from_port = 1024
     to_port = 65535
   }
 

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -222,45 +222,5 @@ resource "aws_security_group" "build_private_sg" {
 resource "aws_security_group" "build_public_sg" {
   vpc_id = "${aws_vpc.build_vpc.id}"
 
-  # Allow ephemeral ports from anywhere
-  ingress {
-    protocol = "tcp"
-    cidr_blocks = [
-      "0.0.0.0/0"
-    ]
-    from_port = 1024
-    to_port = 65535
-  }
-
-  # Allow HTTP (needed for apt-get)
-  egress {
-    protocol = "tcp"
-    cidr_blocks = [
-      "0.0.0.0/0"
-    ]
-    from_port = 80
-    to_port = 80
-  }
-
-  # Allow HTTPS
-  egress {
-    protocol = "tcp"
-    cidr_blocks = [
-      "0.0.0.0/0"
-    ]
-    from_port = 443
-    to_port = 443
-  }
-
-  # Allow egress to the private subnet via ephemeral ports
-  egress {
-    protocol = "tcp"
-    cidr_blocks = [
-      "${aws_subnet.build_private_subnet.cidr_block}"
-    ]
-    from_port = 1024
-    to_port = 65535
-  }
-
   tags = "${var.tags}"
 }


### PR DESCRIPTION
I added support for AWS CodePipeline to this repo.  I have it deployed to our AWS account now.

Here are some things I think we should consider before merging this pull request:
* I'm not sure if we want to use CodePipeline instead of or in addition to TravisCI.  This was a test case.
* Maybe this code should be in its own repo.  A lot of this code could possibly be refactored into a Terraform module that we could reuse for deploying AWS CodePipeline for other projects.
* I don't see a mechanism for CodePipeline to provide visual feedback in GitHub like TravisCI does (with the :heavy_check_mark:s  and :x:s next to commits).

I wanted to get the ball rolling on this and make sure this code goes someplace (either merged here or moved to its own repo) so it doesn't get lost.