### PR TITLE
README link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ containers:
 * [gatherer](https://github.com/dhs-ncats/gatherer)
 * [scanner](https://github.com/dhs-ncats/scanner)
 * [saver](https://github.com/dhs-ncats/saver)
-* [pshtt_reporter](https://github.com/dhs-ncats/pshtt-reporter)
-* [trustymail_reporter](https://github.com/dhs-ncats/trustymail-reporter)
+* [pshtt_reporter](https://github.com/dhs-ncats/pshtt_reporter)
+* [trustymail_reporter](https://github.com/dhs-ncats/trustymail_reporter)
 
 ## Setup ##
 Before attempting to run this project, you must create a `secrets`


### PR DESCRIPTION
The two "reporter" projects use underscores in their names, not dashes. This change fixes the README links to match.