### PR TITLE
Use the latest version of the cisagov/gatherer Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     #     protocol: tcp
     #     mode: host
   gather:
-    image: 'cisagov/gatherer:1.5.6'
+    image: 'cisagov/gatherer:1.5.7'
     depends_on:
       - redis
     secrets:


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Docker composition to use the latest version of the cisagov/gatherer Docker image.

## 💭 Motivation and context ##

The latest version of the cisagov/gatherer Docker image is built on a more recent base Docker image.  See cisagov/gatherer#89 for details.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.