### PR TITLE
Upgrade to use the latest version of the saver Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   save:
     depends_on:
       - redis
-    image: 'cisagov/saver:1.3.6'
+    image: 'cisagov/saver:1.3.7'
     secrets:
       - source: scan_write_creds
         target: scan_write_creds.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Docker composition to use the latest version of the [cisagov/saver](https://github.com/cisagov/saver) Docker image.

## 💭 Motivation and context ##

See cisagov/saver#87 for more details on the latest [cisagov/saver](https://github.com/cisagov/saver) Docker image.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [ ] Create a release.
